### PR TITLE
Fix issue where --default cannot be disabled. 

### DIFF
--- a/src/Commands/Default.lua
+++ b/src/Commands/Default.lua
@@ -33,9 +33,12 @@ local function Unhook()
 	end
 
 	Command.Event:Disconnect()
+	Command.Event = nil
 end
 
 local function Hook()
+	if Command.Event then return end
+	
 	Command.Event = game.DescendantAdded:Connect(function(obj)
 		pcall(Apply, obj)
 	end)

--- a/src/Commands/Default.lua
+++ b/src/Commands/Default.lua
@@ -37,7 +37,9 @@ local function Unhook()
 end
 
 local function Hook()
-	if Command.Event then return end
+	if Command.Event then
+		return
+	end
 	
 	Command.Event = game.DescendantAdded:Connect(function(obj)
 		pcall(Apply, obj)


### PR DESCRIPTION
Currently if `--default enable` is called twice in a row, then the reference to the first RBXScriptConnection will be overwritten. This pull request fixes the issue by checking if the event is already connected. 